### PR TITLE
RCA-2127: Make minScrollRefreshIntervalMs configurable

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -111,7 +111,7 @@ var Popover = (0, _react.createClass)({
       isOpen: false,
       onOuterAction: function noOperation() {},
       enterExitTransitionDurationMs: 500,
-      minScrollRefreshIntervalMs: null,
+      minScrollRefreshIntervalMs: 200,
       children: null,
       refreshIntervalMs: 200
     };
@@ -358,7 +358,7 @@ var Popover = (0, _react.createClass)({
     this.containerEl.style[jsprefix('Transform')] = this.containerEl.style.transform;
   },
   trackPopover: function trackPopover() {
-    var minScrollRefreshIntervalMs = this.props.minScrollRefreshIntervalMs || 200;
+    var minScrollRefreshIntervalMs = this.props.minScrollRefreshIntervalMs;
     var minResizeRefreshIntervalMs = 200;
 
     /* Get references to DOM elements. */

--- a/build/index.js
+++ b/build/index.js
@@ -98,6 +98,7 @@ var Popover = (0, _react.createClass)({
     isOpen: _react.PropTypes.bool,
     onOuterAction: _react.PropTypes.func,
     enterExitTransitionDurationMs: _react.PropTypes.number,
+    minScrollRefreshIntervalMs: _react.PropTypes.number,
     className: _react.PropTypes.string,
     style: _react.PropTypes.object
   },
@@ -110,6 +111,7 @@ var Popover = (0, _react.createClass)({
       isOpen: false,
       onOuterAction: function noOperation() {},
       enterExitTransitionDurationMs: 500,
+      minScrollRefreshIntervalMs: null,
       children: null,
       refreshIntervalMs: 200
     };
@@ -152,6 +154,7 @@ var Popover = (0, _react.createClass)({
 
     var pickerSettings = {
       preferPlace: this.props.preferPlace,
+      minScrollRefreshIntervalMs: this.props.minScrollRefreshIntervalMs,
       place: this.props.place
     };
 
@@ -355,7 +358,7 @@ var Popover = (0, _react.createClass)({
     this.containerEl.style[jsprefix('Transform')] = this.containerEl.style.transform;
   },
   trackPopover: function trackPopover() {
-    var minScrollRefreshIntervalMs = 200;
+    var minScrollRefreshIntervalMs = this.props.minScrollRefreshIntervalMs || 200;
     var minResizeRefreshIntervalMs = 200;
 
     /* Get references to DOM elements. */


### PR DESCRIPTION
minScrollRefreshIntervalMs was hardcoded as 200, causing defect in some situation. Make it configurable and default value to 200 so won't affect others. 